### PR TITLE
Dismiss notifications without input

### DIFF
--- a/gh-tidy-notifications
+++ b/gh-tidy-notifications
@@ -15,7 +15,7 @@ gh api notifications --paginate --jq '.[] | [.subject.url,.subject.type,.url] | 
 
         if [[ "$STATE" == "closed" ]]; then
             echo "  Marking closed item as read: $THREAD_URL"
-            gh api -X PATCH $THREAD_URL
+            gh api -X PATCH --silent $THREAD_URL
         fi
     fi
 done


### PR DESCRIPTION
When a PATCH request is made with `gh` it opens an instance of `vim` essentially asking for the body of the PATCH request. The `--silent` parameter stops `vim` from opening for each request which makes this extension much more usable.